### PR TITLE
FEAT : #3 make authentication using passport

### DIFF
--- a/config/configuration.ts
+++ b/config/configuration.ts
@@ -1,21 +1,21 @@
 export default () => ({
-	database: {
-		host: process.env.DB_HOST,
-		port: parseInt(process.env.DB_PORT, 10),
-		user: process.env.DB_USERNAME,
-		password: process.env.DB_PASSWORD,
-		name: process.env.DB_NAME,
-	},
-	jwt: {
-		secret: process.env.JWT_SECRET,
-	},
-	ft: {
-		id: process.env.FT_CLIENT_ID,
-		secret: process.env.FT_CLIENT_SECRET,
-		callback: process.env.FT_CALLBACK,
-	},
-	session: {
-		secret: process.env.SESSION_SECRET,
-	},
-	client_address: process.env.CLIENT_ADDRESS
+  database: {
+    host: process.env.DB_HOST,
+    port: parseInt(process.env.DB_PORT, 10),
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    name: process.env.DB_NAME,
+  },
+  jwt: {
+    secret: process.env.JWT_SECRET,
+  },
+  ft: {
+    id: process.env.FT_CLIENT_ID,
+    secret: process.env.FT_CLIENT_SECRET,
+    callback: process.env.FT_CALLBACK,
+  },
+  session: {
+    secret: process.env.SESSION_SECRET,
+  },
+  client_address: process.env.CLIENT_ADDRESS,
 });

--- a/config/configuration.ts
+++ b/config/configuration.ts
@@ -1,17 +1,21 @@
 export default () => ({
-  database: {
-    host: process.env.DB_HOST,
-    port: parseInt(process.env.DB_PORT, 10),
-    user: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
-    name: process.env.DB_NAME,
-  },
-  jwt: {
-	secret: process.env.JWT_SECRET,
+	database: {
+		host: process.env.DB_HOST,
+		port: parseInt(process.env.DB_PORT, 10),
+		user: process.env.DB_USERNAME,
+		password: process.env.DB_PASSWORD,
+		name: process.env.DB_NAME,
+	},
+	jwt: {
+		secret: process.env.JWT_SECRET,
 	},
 	ft: {
 		id: process.env.FT_CLIENT_ID,
 		secret: process.env.FT_CLIENT_SECRET,
-		callback: process.env.FT_CLIENT_CALLBACK,
+		callback: process.env.FT_CALLBACK,
 	},
+	session: {
+		secret: process.env.SESSION_SECRET,
+	},
+	client_address: process.env.CLIENT_ADDRESS
 });

--- a/config/configuration.ts
+++ b/config/configuration.ts
@@ -1,9 +1,17 @@
 export default () => ({
   database: {
     host: process.env.DB_HOST,
-    port: parseInt(process.env.DB_PORT, 5432),
+    port: parseInt(process.env.DB_PORT, 10),
     user: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     name: process.env.DB_NAME,
   },
+  jwt: {
+	secret: process.env.JWT_SECRET,
+	},
+	ft: {
+		id: process.env.FT_CLIENT_ID,
+		secret: process.env.FT_CLIENT_SECRET,
+		callback: process.env.FT_CLIENT_CALLBACK,
+	},
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "format": "prettier --write \"config/**/*.ts\" \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,15 +1,16 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import configuration from 'config/configuration';
-import { join } from 'path/posix';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { User } from './user/entity/user.entity';
+import { AuthModule } from './auth/auth.module';
+import { JwtMiddleware } from './auth/middleware/jwt.middleware';
 import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
+    AuthModule,
     ConfigModule.forRoot({
       isGlobal: true,
       load: [configuration],
@@ -33,4 +34,8 @@ import { UserModule } from './user/user.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(JwtMiddleware).forRoutes('*');
+  }
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,57 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  Post,
+  Req,
+  Res,
+  Session,
+  UseGuards,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request, Response } from 'express';
+import { User } from 'src/user/entity/user.entity';
+import { AuthService } from './auth.service';
+import { FTAuthGuard } from './guard/ft-auth.guard';
+
+@Controller('auth')
+export class AuthController {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @UseGuards(FTAuthGuard)
+  @Get('login')
+  async login(
+    @Req() req,
+    @Res({ passthrough: true }) res: Response,
+    @Session() session: Record<string, User>,
+  ) {
+    const token = await this.authService.login(req.user, session);
+    if (token) {
+      res.cookie('access_token', token);
+      return res.redirect(
+        `${this.configService.get<string>('CLIENT_ADDRESS')}/main`,
+      );
+    }
+    return res.redirect(
+      `${this.configService.get<string>('CLIENT_ADDRESS')}/register`,
+    );
+  }
+
+  @Post('register')
+  async register(
+    @Body('nickname') nickname: string,
+    @Res({ passthrough: true }) res: Response,
+    @Session() session: any,
+  ) {
+    if (!session.newUser) throw new ForbiddenException();
+    const token = await this.authService.register(nickname, session);
+    res.cookie('access_token', token.access_token);
+    session.destroy();
+    return true;
+  }
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -34,11 +34,11 @@ export class AuthController {
     if (token) {
       res.cookie('access_token', token);
       return res.redirect(
-        `${this.configService.get<string>('CLIENT_ADDRESS')}/main`,
+        `${this.configService.get<string>('client_address')}/main`,
       );
     }
     return res.redirect(
-      `${this.configService.get<string>('CLIENT_ADDRESS')}/register`,
+      `${this.configService.get<string>('client_address')}/register`,
     );
   }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,29 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { UserModule } from 'src/user/user.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { FTStrategy } from './strategy/ft.strategy';
+
+@Module({
+  imports: [
+    UserModule,
+    PassportModule,
+    HttpModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('jwt.secret'),
+        signOptions: { expiresIn: '1d' },
+      }),
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, FTStrategy],
+  exports: [AuthService, JwtModule],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { User } from 'src/user/entity/user.entity';
+import { UserService } from 'src/user/user.service';
+import { JwtDto } from './dto/jwt.dto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly userService: UserService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async sign({ id }) {
+    const payload = { id: id };
+    return {
+      access_token: this.jwtService.sign(payload),
+    };
+  }
+
+  async login(user: any, session: Record<string, User>) {
+    try {
+      const exist = await this.userService.getUserById(user.id);
+      if (exist) return this.sign(exist);
+    } catch (error) {}
+
+    const newUser = new User();
+    newUser.id = user.id;
+    newUser.nickname = user.login;
+    newUser.intraLogin = user.login;
+    newUser.useTwoFactor = false;
+    newUser.status = 0;
+    newUser.avatar = user.image_url;
+    newUser.ladderLevel = 0;
+    newUser.ladderPoint = 0;
+
+    //임시 session에 유저 저장
+    session.newUser = newUser;
+    return null;
+  }
+
+  //register 이후에 jwt 리턴
+  async register(nickname: string, session: any) {
+    session.newUser.nickname = nickname;
+    await this.userService.createUser(session.newUser);
+
+    return this.login(session.newUser, session); //will return jwt
+  }
+
+  //jwt validate
+  async validate(user: JwtDto) {
+    return await this.userService.getUserById(user.id);
+  }
+}

--- a/src/auth/dto/jwt.dto.ts
+++ b/src/auth/dto/jwt.dto.ts
@@ -1,0 +1,3 @@
+export class JwtDto {
+  readonly id: number;
+}

--- a/src/auth/guard/ft-auth.guard.ts
+++ b/src/auth/guard/ft-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class FTAuthGuard extends AuthGuard('ft') {}

--- a/src/auth/guard/jwt-auth.guard.ts
+++ b/src/auth/guard/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/auth/middleware/jwt.middleware.ts
+++ b/src/auth/middleware/jwt.middleware.ts
@@ -1,0 +1,28 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Request, Response, NextFunction } from 'express';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class JwtMiddleware implements NestMiddleware {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly jwtService: JwtService,
+    private readonly authService: AuthService,
+  ) {}
+  async use(req: Request, res: Response, next: NextFunction) {
+    const token = req.cookies['access_token'];
+    try {
+      const decoded = await this.jwtService.verify(token.access_token, {
+        secret: this.configService.get<string>('jwt.secret'),
+      });
+      const leftExpiredTime = decoded.exp - Date.now() / 1000;
+      if (leftExpiredTime < 3600) {
+        const newToken = await this.authService.sign({ id: decoded.id });
+        res.cookie('access_token', newToken.access_token);
+      }
+    } catch (error) {}
+    next();
+  }
+}

--- a/src/auth/strategy/ft.strategy.ts
+++ b/src/auth/strategy/ft.strategy.ts
@@ -1,0 +1,42 @@
+import { HttpService } from '@nestjs/axios';
+import {
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-oauth2';
+import { lastValueFrom } from 'rxjs';
+
+@Injectable()
+export class FTStrategy extends PassportStrategy(Strategy, 'ft') {
+  constructor(private http: HttpService, configService: ConfigService) {
+    super({
+      authorizationURL: `https://api.intra.42.fr/oauth/authorize?client_id=${configService.get<string>(
+        'ft.id',
+      )}&redirect_uri=${configService.get<string>(
+        'ft.callback',
+      )}&response_type=code`,
+      tokenURL: 'https://api.intra.42.fr/oauth/token',
+      scope: 'profile',
+      clientID: configService.get<string>('ft.id'),
+      clientSecret: configService.get<string>('ft.secret'),
+      callbackURL: configService.get<string>('ft.callback'),
+    });
+  }
+
+  async validate(accessToken: string): Promise<any> {
+    const req = this.http.get('https://api.intra.42.fr/v2/me', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    try {
+      const { data } = await lastValueFrom(req);
+      if (!data) throw new UnauthorizedException();
+      return data;
+    } catch (error) {
+      throw new ForbiddenException();
+    }
+  }
+}

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -1,0 +1,32 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-jwt';
+import { AuthService } from '../auth.service';
+import { JwtDto } from '../dto/jwt.dto';
+
+var cookieExtractor = function (req) {
+  var token = null;
+  if (req && req.cookies) {
+    token = req.cookies['access_token'];
+  }
+  return token;
+};
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor(config: ConfigService, private authService: AuthService) {
+    super({
+      jwtFromRequest: cookieExtractor,
+      ignoreExpiration: false,
+      secretOrKey: config.get<string>('jwt.secret'),
+    });
+  }
+  async validate(payload: JwtDto) {
+    try {
+      return this.authService.validate(payload);
+    } catch (error) {
+      throw new ForbiddenException();
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,24 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import * as session from 'express-session';
+import * as cookieParser from 'cookie-parser';
+import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  const configService = app.get<ConfigService>(ConfigService);
+  app.use(
+    cookieParser(),
+    session({
+      secret: 'this is secret',
+      resave: false,
+      saveUninitialized: true,
+    }),
+  );
+  app.enableCors({
+    origin: configService.get<string>('client_address'),
+    credentials: true,
+  }); // to resolve CORS problem
+  await app.listen(5000);
 }
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ async function bootstrap() {
   app.use(
     cookieParser(),
     session({
-      secret: 'this is secret',
+      secret: configService.get<string>('session.secret'),
       resave: false,
       saveUninitialized: true,
     }),

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Query, Req, UseFilters } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+} from '@nestjs/common';
 import { UserService } from './user.service';
 
 @Controller('user')
@@ -11,9 +19,9 @@ export class UserController {
   }
 
   @Post()
-  async creatUser(@Body() req, @Body('nickname')  nickname: string) {
+  async creatUser(@Body() req) {
     // req -> req.user로 변경이 필요
-    return this.userService.createUser(req, nickname);
+    return this.userService.createUser(req);
   }
 
   @Get(':id')

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -8,6 +8,6 @@ import { UserService } from './user.service';
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [UserController],
   providers: [UserService],
-  exports: [UserService]
+  exports: [UserService],
 })
 export class UserModule {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entity/user.entity';
@@ -7,12 +11,12 @@ import { User } from './entity/user.entity';
 export class UserService {
   constructor(
     @InjectRepository(User)
-    private readonly userRepository: Repository<User>) {}
+    private readonly userRepository: Repository<User>,
+  ) {}
 
-  async createUser(user: User, nickname: string) {
+  async createUser(user: User) {
     let newUser: User = this.userRepository.create(user);
-    
-    newUser.nickname = nickname;
+
     try {
       return await this.userRepository.insert(newUser);
     } catch (error) {
@@ -27,12 +31,11 @@ export class UserService {
 
   async getUserById(id: number) {
     const user: User = await this.userRepository.findOne(id);
-    if (!user)
-      throw new NotFoundException();
+    if (!user) throw new NotFoundException();
     return user;
   }
 
   async deleteUserById(id: number) {
-    await this.userRepository.delete({id: id});
+    await this.userRepository.delete({ id: id });
   }
-} 
+}


### PR DESCRIPTION
## 작업 내용

* callback이 front에서 back으로 변경되었습니다.
* register은 임시 session을 사용해 구현했습니다.
* Jwt의 유효기간은 1일이며, 1시간 미만일 시 새로운 jwt를 발급하는 것으로 구현했습니다.
* front에서 register 성공/실패시 main/login창으로 redirection 하는 간단한 테스트 코드를 작성했습니다.
  -> 나중에 frontend 레포에 브랜치 파서 올려둘게요. (main, login, register 구현시 유용하게 써먹을 것 같아요..)
* 현재 nickname의 유효성 검증에 대한 내용은 없습니다.

## 공유 사항

### 1. 기존 방식에서 발생한 문제

전에 hjung님이 slack에 먼저 질문을 주셔서 간단히 답을 드렸습니다.
아래 내용은 해당 답변의 확장판(?)이니 스킵하셔도 됩니다.

저희가 회의를 통해 정한 auth 구현부의 대략적인 흐름은 callback을 front로 설정해서 code를 받고, 이렇게 생성된 code를 다시 backend로 넘겨 진행하는 식이었습니다.
> 기존 방식에 대한 내용은 Notion page의 "회의록 정리 (명세)" 또는 "Issue 관련" 페이지에 있으니 참고해주세요. 

그래서 처음에는 front에서 기존에 한 번 사용했던 code값을 다시 넘기는 방식으로 register 구현을 했습니다. 그런데 구현 이후에 진행한 테스트에서, AuthGuard에서 code값이 계속 만료됐다는 에러가 발생했습니다. 처음엔 기존에 AuthGuard를 통과했던 code인데, 왜 다시 사용하면 에러가 뜨는지 몰라 찾아보니 ina님이 다음과 같은 문서를 찾아주셨습니다. 그런데 [RFC 6749 Section 4.1.2 Authorization Response](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2)에는 다음과 같이 명시되어있습니다. 
> **The client MUST NOT use the authorization code _more than once._**

따라서, authorization code의 특성을 제대로 알지 못한채로 방법을 정한 것에 문제가 있었다고 판단해 다른 방법으로 auth를 구현했습니다. 물론 42api를 한번 더 호출해 새로운 code값을 받는 방법도 있겠지만, 이는 흐름상 맞지 않다고 판단했습니다.

### 2. 새로운 방법 (슬랙에 있는 내용과 살짝 다릅니다.)
참고로 아래 `3-2-1` 부분의 유효성 검증 부분은 구현되지 않은 상태입니다. 
```
1. front에서 code 없는 상태로 42api를 요청합니다.
2. callback을 back으로 설정해 code를 back에서 받습니다.
3. 다음 code를 가진 back쪽에서 42api 호출 결과와 (req.user) userDB를 체크합니다.
   3-1. exist라면, jwt를 cookie에 넣어준 뒤 front를 main으로 redirect합니다.
   3-2. not exist라면, 받아온 user info를 session.newUser에 저장한 뒤, front의 register 페이지로 redirect 시킵니다.
      3-2-1. front에서 axios post로 유효성 검증을 받은 닉네임을 back으로 보냅니다. 
             * 이때 신규 유저라면(session.newUser가 있는경우) 아까 만들어둔 session.newUser.nickname에 저장한 뒤 DB에 저장->cookie에 jwt 저장->session 삭제 순->jwt 리턴 순으로 진행됩니다. 
             * 기존 유저라면 forbidden error를 throw합니다. 
      3-2-3. front에서 access_token을 받은 경우에는 main으로, throw를 받은 경우 login 창으로 redirection합니다.
```

close #3