### PR TITLE
Feat/#56/channel api & gateway

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,7 +12,7 @@ import { OTPModule } from './otp/otp.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { MatchModule } from './match/match.module';
 import { DmModule } from './dm/dm.module';
-
+import { ChannelModule } from './channel/channel.module';
 
 @Module({
   imports: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -49,6 +49,7 @@ import { ChannelModule } from './channel/channel.module';
     OTPModule,
     MatchModule,
     DmModule,
+    ChannelModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -27,16 +27,18 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   @Get('test')
   async test(@Req() req, @Res({ passthrough: true }) res: Response) {
-    const token = await this.authService.sign(
-      req.user,
-      req.user.otpSecret == null,
-    );
-    if (token) {
-      res.cookie('access_token', token);
-      return res.redirect(
-        `${this.configService.get<string>('client_address')}/main`,
+    try {
+      const token = await this.authService.sign(
+        req.user,
+        req.user.otpSecret == null,
       );
-    }
+      if (token) {
+        res.cookie('access_token', token);
+        return res.redirect(
+          `${this.configService.get<string>('client_address')}/main`,
+        );
+      }
+    } catch (error) {}
   }
 
   @UseGuards(FTAuthGuard)

--- a/src/channel/channel.controller.ts
+++ b/src/channel/channel.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { ChannelService } from './channel.service';
+
+@UseGuards(JwtAuthGuard)
+@Controller('channel')
+export class ChannelController {
+  constructor(private readonly channelService: ChannelService) {}
+
+  @Get()
+  async getAll() {
+    return this.channelService.getAllChannel();
+  }
+
+  @Get('me')
+  async getMyChannel(@Req() req) {
+    return this.channelService.getMyChannel(req);
+  }
+}

--- a/src/channel/channel.gateway.ts
+++ b/src/channel/channel.gateway.ts
@@ -1,0 +1,93 @@
+import { Inject, UseGuards } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { Server } from 'socket.io';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { cookieExtractor, JwtStrategy } from 'src/auth/strategy/jwt.strategy';
+import { SocketUser } from 'src/socket/socket-user';
+import { SocketUserService } from 'src/socket/socket-user.service';
+import { ChannelService } from './channel.service';
+import { CreateChannelDto } from './dto/create-channel.dto';
+
+@UseGuards(JwtAuthGuard)
+@WebSocketGateway(4501, { namespace: 'channel' })
+export class ChannelGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  constructor(
+    private jwtService: JwtService,
+    private jwtStrategy: JwtStrategy,
+    private channelService: ChannelService,
+    @Inject('CHANNEL_SOCKET_USER_SERVICE')
+    private socketUserService: SocketUserService,
+  ) {}
+  @WebSocketServer() server: Server;
+
+  async handleConnection(client: SocketUser) {
+    console.log(`Client ${client.id} Connected to channel`);
+    try {
+      const token = cookieExtractor(client);
+      const userPayload = this.jwtService.verify(token);
+      const user = await this.jwtStrategy.validate(userPayload);
+      client.user = user;
+      console.log(client.rooms);
+      console.log(user.id, user.intraLogin);
+      this.socketUserService.addSocket(client);
+    } catch (error) {
+      console.log(error);
+      client.disconnect(true);
+    }
+  }
+  async handleDisconnect(client: SocketUser) {
+    console.log(`Client ${client.id} Disconnected`);
+    try {
+      const token = cookieExtractor(client);
+      const userPayload = this.jwtService.verify(token);
+      const user = await this.jwtStrategy.validate(userPayload);
+      client.user = user;
+      this.socketUserService.removeSocket(client);
+    } catch (error) {}
+  }
+
+  @SubscribeMessage('createChannel')
+  async createChannel(
+    @MessageBody() data: CreateChannelDto,
+    @ConnectedSocket() client: SocketUser,
+  ) {
+    data.ownerId = client.user.id;
+    const channelId = await this.channelService.createChannel(data);
+    this.server.emit('channelCreated', channelId);
+  }
+
+  @SubscribeMessage('joinChannel')
+  async joinChannel(
+    @MessageBody() data: any,
+    @ConnectedSocket() client: SocketUser,
+  ) {
+    client.join(data.toString());
+    const myChannel = await this.channelService.getMyChannel(client);
+    if (!myChannel.some((channel) => channel.roomId == data))
+      this.channelService.joinChannel(data, client.user.id);
+    console.log(client.rooms);
+  }
+
+  @SubscribeMessage('msgToChannel')
+  handleMessage(
+    @MessageBody() data: any,
+    @ConnectedSocket() client: SocketUser,
+  ) {
+    const payload = {
+      text: data.text,
+      name: client.user.intraLogin,
+    };
+    this.server.to(data.roomId).emit('msgToClient', payload);
+  }
+}

--- a/src/channel/channel.module.ts
+++ b/src/channel/channel.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
+import { UserModule } from 'src/user/user.module';
+import { ChannelController } from './channel.controller';
+import { ChannelGateway } from './channel.gateway';
+import { ChannelService } from './channel.service';
+import { ChannelSocketUserService } from './channel.socket-user.service';
+import { Channel, ChannelMember } from './entity/channel.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Channel, ChannelMember]),
+    AuthModule,
+    UserModule,
+  ],
+  controllers: [ChannelController],
+  providers: [ChannelService, ChannelGateway, ChannelSocketUserService],
+})
+export class ChannelModule {}

--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { cookieExtractor, JwtStrategy } from 'src/auth/strategy/jwt.strategy';
+import { Repository } from 'typeorm';
+import { ChannelListDto } from './dto/channel-list.dto';
+import { Channel, ChannelMember } from './entity/channel.entity';
+
+@Injectable()
+export class ChannelService {
+  constructor(
+    private jwtService: JwtService,
+    private jwtStrategy: JwtStrategy,
+    @InjectRepository(Channel)
+    private readonly channelRepository: Repository<Channel>,
+    @InjectRepository(ChannelMember)
+    private channelMemberRepository: Repository<ChannelMember>,
+  ) {}
+
+  channelMap: Map<number, ChannelListDto> = new Map();
+
+  async onModuleInit() {
+    await this.getAllChannelDB();
+  }
+
+  async getAllChannelDB() {
+    const channels: Channel[] = await this.channelRepository.find();
+    if (!channels) return;
+    for (const channel of channels) {
+      const instance = new ChannelListDto();
+      instance.roomId = channel.id;
+      instance.title = channel.title;
+      instance.isProtected = channel.type === 2 ? true : false;
+      const memCnt = await this.channelMemberRepository.findAndCount({
+        where: {
+          channelID: channel.id,
+        },
+        join: {
+          alias: 'channel_member',
+          leftJoinAndSelect: {
+            channel: 'channel_member.channel',
+          },
+        },
+      });
+      instance.memberCount = memCnt[1];
+      this.channelMap.set(instance.roomId, instance);
+    }
+  }
+
+  async getAllChannel() {
+    this.channelMap.clear();
+    await this.getAllChannelDB();
+    return [...this.channelMap.values()];
+  }
+
+  async getMyChannel(req) {
+    const token = cookieExtractor(req); //error
+    const userPayload = this.jwtService.verify(token);
+    const user = await this.jwtStrategy.validate(userPayload);
+    const myChannel = [];
+    const channels = await this.channelMemberRepository.find({
+      select: ['channel'],
+      where: {
+        userID: user.id,
+      },
+      join: {
+        alias: 'channel_member',
+        leftJoinAndSelect: {
+          channel: 'channel_member.channel',
+        },
+      },
+    });
+    for (const channel of channels) {
+      const instance = new ChannelListDto();
+      instance.roomId = channel.channelID;
+      instance.title = channel.channel.title;
+      instance.isProtected = channel.channel.type === 2 ? true : false;
+      const memCnt = await this.channelMemberRepository.findAndCount({
+        where: {
+          channelID: channel.channelID,
+        },
+        join: {
+          alias: 'channel_member',
+          leftJoinAndSelect: {
+            channel: 'channel_member.channel',
+          },
+        },
+      });
+      instance.memberCount = memCnt[1];
+      myChannel.push(instance);
+    }
+    return myChannel;
+  }
+}

--- a/src/channel/channel.socket-user.service.ts
+++ b/src/channel/channel.socket-user.service.ts
@@ -1,0 +1,8 @@
+import { Scope } from '@nestjs/common';
+import { SocketUserService } from 'src/socket/socket-user.service';
+
+export const ChannelSocketUserService = {
+  provide: 'CHANNEL_SOCKET_USER_SERVICE',
+  useClass: SocketUserService,
+  scope: Scope.DEFAULT,
+};

--- a/src/channel/dto/channel-list.dto.ts
+++ b/src/channel/dto/channel-list.dto.ts
@@ -1,0 +1,9 @@
+export class ChannelListDto {
+  roomId: number;
+
+  title: string;
+
+  isProtected: boolean;
+
+  memberCount: number;
+}

--- a/src/channel/dto/create-channel.dto.ts
+++ b/src/channel/dto/create-channel.dto.ts
@@ -1,0 +1,9 @@
+export class CreateChannelDto {
+  readonly title: string;
+
+  readonly type: number;
+
+  readonly password?: string;
+
+  ownerId: number;
+}

--- a/src/channel/entity/channel.entity.ts
+++ b/src/channel/entity/channel.entity.ts
@@ -1,0 +1,77 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryColumn,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../user/entity/user.entity';
+
+@Entity('channel')
+export class Channel {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false })
+  title: string;
+
+  @Column({ nullable: false })
+  type: number;
+
+  @Column({ nullable: true })
+  password: string;
+
+  @OneToMany(() => ChannelMember, (channelMember) => channelMember.channelID)
+  channelIDs: ChannelMember[];
+}
+
+@Entity('channel_member')
+export class ChannelMember {
+  @ManyToOne(() => Channel, (channel) => channel.channelIDs, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn({ name: 'channelID' })
+  channel: Channel;
+  @PrimaryColumn()
+  channelID: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userID' })
+  user: User;
+  @PrimaryColumn()
+  userID: number;
+
+  @OneToMany(() => ChannelMessage, (message) => message.sentBy)
+  messages: ChannelMessage[];
+
+  @Column()
+  permissionType: number;
+
+  @Column()
+  penalty: number;
+}
+
+@Entity('channel_message')
+export class ChannelMessage {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => ChannelMember, (message) => message.messages, {
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn([
+    { name: 'cid', referencedColumnName: 'channelID' },
+    { name: 'uid', referencedColumnName: 'userID' },
+  ])
+  sentBy: ChannelMember;
+
+  @Column()
+  message: string;
+
+  @Column()
+  timestamp: Date;
+}


### PR DESCRIPTION
## 작업 내용
- #23 
- #24 
- #55 (일부)
- #56 

위 이슈에 해당하는 사항들을 구현했습니다. 
구현한 항목 / 앞으로 구현할 항목은 [front에 해당하는 PR](https://github.com/Architects8080/frontend/pull/20) 에 대강 적어뒀습니다.
구현 안된 부분은 좀 더 자세히 정리해서 이슈 새로 만들 예정입니다.

## 공유 사항
기능단위로 커밋 나눴으니, 커밋 단위로 보시면 될 것 같습니다.
otp 이후 인증이 안된다고 했던 문제 해결한 커밋도 포함되어 있습니다. 
오류메시지에서 async에서 try, catch 문 없이 exception을 발생시키면 안된다고 하길래 try catch 추가했더니 일단 인증로직은 잘 작동했습니다.