### PR TITLE
Feat/#73/channel RoleGuard 활용해 사용자 권한에 따른 endpoint 접근 제한 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,7 +15,6 @@ import { DmModule } from './dm/dm.module';
 import { CommunityModule } from './community/community.module';
 import { ChannelModule } from './channel/channel.module';
 
-
 @Module({
   imports: [
     ConfigModule.forRoot({

--- a/src/channel/channel-role.service.ts
+++ b/src/channel/channel-role.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Channel, ChannelMember } from './entity/channel.entity';
+
+@Injectable()
+export class ChannelRoleService {
+  constructor(
+    @InjectRepository(Channel)
+    private readonly channelRepository: Repository<Channel>,
+    @InjectRepository(ChannelMember)
+    private channelMemberRepository: Repository<ChannelMember>,
+  ) {}
+
+  // 해당 유저의 role 해당 room에서의 role 확인
+  async getRole(roomId: number, userId: number) {
+    const role = await this.channelMemberRepository.find({
+      select: ['permissionType'],
+      where: {
+        channelID: roomId,
+        userID: userId,
+      },
+    });
+    console.log('mypermission:', role[0].permissionType);
+    return role[0].permissionType;
+  }
+}

--- a/src/channel/channel.controller.ts
+++ b/src/channel/channel.controller.ts
@@ -1,6 +1,16 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 import { ChannelService } from './channel.service';
+import { UpdateChannelDto } from './dto/update-channel.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('channel')
@@ -21,5 +31,13 @@ export class ChannelController {
   @Post('enter-pw')
   async logIn(@Body() req) {
     return this.channelService.checkPassword(req.roomId, req.password);
+  }
+
+  @Put(':id')
+  async updateChannel(
+    @Param('id') roomId: number,
+    @Body() updateData: UpdateChannelDto,
+  ) {
+    return this.channelService.updateChannel(roomId, updateData);
   }
 }

--- a/src/channel/channel.controller.ts
+++ b/src/channel/channel.controller.ts
@@ -9,10 +9,12 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { Roles } from 'src/channel/guard/roles.decorator';
+import { RolesGuard } from 'src/channel/guard/roles.guard';
 import { ChannelService } from './channel.service';
 import { UpdateChannelDto } from './dto/update-channel.dto';
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('channel')
 export class ChannelController {
   constructor(private readonly channelService: ChannelService) {}
@@ -34,6 +36,7 @@ export class ChannelController {
   }
 
   @Put(':id')
+  @Roles('owner')
   async updateChannel(
     @Param('id') roomId: number,
     @Body() updateData: UpdateChannelDto,

--- a/src/channel/channel.module.ts
+++ b/src/channel/channel.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from 'src/auth/auth.module';
 import { UserModule } from 'src/user/user.module';
+import { ChannelRoleService } from './channel-role.service';
 import { ChannelController } from './channel.controller';
 import { ChannelGateway } from './channel.gateway';
 import { ChannelService } from './channel.service';
@@ -15,6 +16,11 @@ import { Channel, ChannelMember } from './entity/channel.entity';
     UserModule,
   ],
   controllers: [ChannelController],
-  providers: [ChannelService, ChannelGateway, ChannelSocketUserService],
+  providers: [
+    ChannelService,
+    ChannelGateway,
+    ChannelSocketUserService,
+    ChannelRoleService,
+  ],
 })
 export class ChannelModule {}

--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -2,12 +2,12 @@ import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { JwtStrategy } from 'src/auth/strategy/jwt.strategy';
-import { User } from 'src/user/entity/user.entity';
 import { Repository } from 'typeorm';
 import { ChannelListDto } from './dto/channel-list.dto';
 import { CreateChannelDto } from './dto/create-channel.dto';
 import { Channel, ChannelMember } from './entity/channel.entity';
 import * as bcrypt from 'bcrypt';
+import { UpdateChannelDto } from './dto/update-channel.dto';
 
 @Injectable()
 export class ChannelService {
@@ -169,5 +169,14 @@ export class ChannelService {
       },
     });
     if (memCnt[1] === 0) await this.channelRepository.delete({ id: roomId });
+  }
+
+  async updateChannel(roomId: number, updateData: UpdateChannelDto) {
+    const updateChannel = await this.channelRepository.findOne(roomId);
+    console.log(updateChannel);
+    for (const key in updateData) {
+      updateChannel[key] = updateData[key];
+    }
+    await this.channelRepository.save(updateChannel);
   }
 }

--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -1,7 +1,5 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
-import { JwtStrategy } from 'src/auth/strategy/jwt.strategy';
 import { Repository } from 'typeorm';
 import { ChannelListDto } from './dto/channel-list.dto';
 import { CreateChannelDto } from './dto/create-channel.dto';
@@ -12,8 +10,6 @@ import { UpdateChannelDto } from './dto/update-channel.dto';
 @Injectable()
 export class ChannelService {
   constructor(
-    private jwtService: JwtService,
-    private jwtStrategy: JwtStrategy,
     @InjectRepository(Channel)
     private readonly channelRepository: Repository<Channel>,
     @InjectRepository(ChannelMember)
@@ -157,18 +153,12 @@ export class ChannelService {
       userID: userId,
       channelID: roomId,
     });
-    const memCnt = await this.channelMemberRepository.findAndCount({
+    const memCnt = await this.channelMemberRepository.count({
       where: {
         channelID: roomId,
       },
-      join: {
-        alias: 'channel_member',
-        leftJoinAndSelect: {
-          channel: 'channel_member.channel',
-        },
-      },
     });
-    if (memCnt[1] === 0) await this.channelRepository.delete({ id: roomId });
+    if (memCnt === 0) await this.channelRepository.delete({ id: roomId });
   }
 
   async updateChannel(roomId: number, updateData: UpdateChannelDto) {

--- a/src/channel/dto/update-channel.dto.ts
+++ b/src/channel/dto/update-channel.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateChannelDto } from './create-channel.dto';
+
+export class UpdateChannelDto extends PartialType(CreateChannelDto) {}

--- a/src/channel/entity/channel.entity.ts
+++ b/src/channel/entity/channel.entity.ts
@@ -1,5 +1,6 @@
 import {
   BeforeInsert,
+  BeforeUpdate,
   Column,
   Entity,
   JoinColumn,
@@ -30,6 +31,7 @@ export class Channel {
   channelIDs: ChannelMember[];
 
   @BeforeInsert()
+  @BeforeUpdate()
   async hashPassword(): Promise<void> {
     try {
       this.password = await bcrypt.hash(this.password, 10);

--- a/src/channel/guard/roles.decorator.ts
+++ b/src/channel/guard/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/src/channel/guard/roles.guard.ts
+++ b/src/channel/guard/roles.guard.ts
@@ -1,0 +1,30 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ChannelRoleService } from '../channel-role.service';
+import { RoleDefaultList } from './roles.type';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private readonly channelRoleService: ChannelRoleService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // 권한 목록 가져오기
+    const roles = this.reflector.get<string[]>('roles', context.getHandler());
+    if (!roles) {
+      return true;
+    }
+    // 요청을 보낸 user 의 권한이 위 권한 array 에 있으면 true 반환
+    const request = context.switchToHttp().getRequest();
+    const result = await this.channelRoleService.getRole(
+      request.params.id,
+      request.user.id,
+    );
+    if (!roles.includes(RoleDefaultList[`${+result}`])) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/channel/guard/roles.type.ts
+++ b/src/channel/guard/roles.type.ts
@@ -1,0 +1,11 @@
+enum MemberRoleEnum {
+  USER = 'user',
+  ADMIN = 'admin',
+  OWNER = 'owner',
+}
+
+export const RoleDefaultList = [
+  MemberRoleEnum.USER,
+  MemberRoleEnum.ADMIN,
+  MemberRoleEnum.OWNER,
+];


### PR DESCRIPTION
## 작업 내용
- #73 중 AuthGuard 적용해 채널 정보 수정은 Owner만 가능하도록 하는 기능 구현.


UPDATE request 는 REST API 로 요청됩니다.
수정할 정보만 보내도 되게 PATCH 메서드를 사용하려고 했으나, 
PATCH와 repository API의 `update()` 를 사용하면 typeorm이 데이터가 수정된걸 알아차리지 못해서 비밀번호가 평문 그대로 저장됩니다.
repository API 중 `save()` 를 사용해야, `@BeforeUpdate()` hook 이 트리거 되어, 
수정된 비밀번호를 암호화해서 저장할 수 있기 때문에 PUT 메서드를 사용했습니다. 


RoleGuard의 경우 권한이 없는 유저가 권한이 필요한 endpoint에 요청을 보내면 403 ForbiddenException을 발생시킵니다.

## 공유 사항
- nestJS의 Guard 이용했습니다. [참고링크](https://docs.nestjs.com/guards#guards)
