### PR TITLE
Feat: #93 notification

### DIFF
--- a/src/community/community.controller.ts
+++ b/src/community/community.controller.ts
@@ -8,13 +8,18 @@ export class CommunityController {
   constructor(private readonly communityService: CommunityService) {}
 
   @Get('friend')
-  async getFriendList(@Req() req) {
+  getFriendList(@Req() req) {
     return this.communityService.getRelationships(req.user.id, true);
   }
 
   @Get('block')
-  async getBlockList(@Req() req) {
+  getBlockList(@Req() req) {
     return this.communityService.getRelationships(req.user.id, false);
+  }
+
+  @Get('notification')
+  getNotificationList(@Req() req) {
+    return this.communityService.getNotifications(req.user.id);
   }
 
   @Get(':friendID')

--- a/src/community/community.module.ts
+++ b/src/community/community.module.ts
@@ -9,6 +9,7 @@ import { CommunityController } from './community.controller';
 import { CommunityGateway } from './community.gateway';
 import { CommunityService } from './community.service';
 import { Block, Friend } from './entity/community.entity';
+import { Notification } from './entity/notification.entity';
 import { SocketUserService } from './socket-user.service';
 
 @Module({
@@ -16,7 +17,8 @@ import { SocketUserService } from './socket-user.service';
     Friend,
     Block,
     User,
-    DirectMessageInfo
+    DirectMessageInfo,
+    Notification
   ]), AuthModule],
   controllers: [CommunityController],
   providers: [

--- a/src/community/dto/notification.ts
+++ b/src/community/dto/notification.ts
@@ -1,0 +1,15 @@
+import { IsNumber } from "class-validator";
+
+export class NotificationDto {
+	@IsNumber()
+	readonly senderID: number;
+
+	@IsNumber()
+	readonly receiverID: number;
+
+	@IsNumber()
+	readonly targetID: number;
+
+	@IsNumber()
+	readonly type: number;
+}

--- a/src/community/entity/notification.entity.ts
+++ b/src/community/entity/notification.entity.ts
@@ -1,0 +1,30 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn, PrimaryGeneratedColumn } from 'typeorm';
+import { User } from "../../user/entity/user.entity";
+
+@Entity('notification')
+export class Notification {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  senderID: number;
+
+  @Column()
+  receiverID: number;
+
+  //채널 초대: roomId
+  //친구 요청: senderID
+  @Column()
+  targetID: number;
+
+  @Column() //0: 친구초대 1: 채팅초대
+  type: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'senderID'})
+  sender: User;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'receiverID' })
+  receiver: User;
+}


### PR DESCRIPTION
## 작업 내용
**notification entity**
![image](https://user-images.githubusercontent.com/45448572/137440512-ba04c488-ea18-4c98-9294-831dbcb3cd95.png)
![image](https://user-images.githubusercontent.com/45448572/137440543-aa8acd45-2775-43ec-8394-6f5940809243.png)


**community service**
- `getNotifications()` notification 목록 불러오기
- `setNotification()` notification 추가 (이미 중복되는 내용이 있을 경우 null 반환)
- `deleteNotification()` notification 삭제
- `getBlockByID` block한 유저인지 확인

</br>

**community controller**
- `getNotificationList()` notification 목록 불러오기

</br>

**community gateway에 notification 서비스 반영**
- 친구 추가 요청시 notification 추가 (중복 요청은 제외)
- 친구 수락/거절 시 notification 삭제

</br>

**친구 신청시 오류 코드 추가**
```
  Success(1) = 친구 신청을 보냈습니다!
  NotFoundUser(2) = "존재하지 않는 플레이어입니다. 다시 시도해주세요."
  AlreadyFriend(3) = "~님과는 이미 친구입니다."
  Myself(4) = "본인 외의 플레이어를 입력해주세요."
  InProgress(5) = "이미 친구 요청을 보냈습니다." //notification 목록에 있음
  Block(6) = "차단한 플레이어입니다. 차단을 해제한 후 다시 시도해주세요."
```
그 외, 대상이 자신을 차단했을 경우
- Success 코드를 응답 받게 됨
- 실제 Notification DB에는 반영되지 않음
- 상대방에게 emit도 전송하지 않음

## 공유 사항
채널 등 다른 곳에서 notification을 사용해야하는 경우, 각자 소켓 통신에서 community service를 불러와서 사용해주세요
