### PR TITLE
FIX : #100 fix friend class-transformer

### DIFF
--- a/src/community/community.gateway.ts
+++ b/src/community/community.gateway.ts
@@ -22,6 +22,8 @@ import { UserStatus } from './data/user-status';
 import { COMMUNITY_SOCKET_USER_SERVICE_PROVIDER } from './community.socket-user.service';
 import { Notification } from 'src/notification/entity/notification.entity';
 import { UserService } from 'src/user/user.service';
+import { deserialize, serialize } from 'class-transformer';
+import { mergeUserAndStatus } from './data/status-user';
 
 @UseGuards(JwtAuthGuard)
 @WebSocketGateway(4500, { namespace: 'community' })
@@ -96,7 +98,10 @@ export class CommunityGateway
     try {
       const friend = await this.userService.getUserById(friendId);
       const friendStatus = this.statusService.getUserStatusById(friendId);
-      client.emit('addFriendUser', { status: friendStatus, ...friend });
+      client.emit(
+        'addFriendUser',
+        JSON.parse(serialize(mergeUserAndStatus(friend, friendStatus))),
+      );
       client.join(`user:${friendId.toString()}`);
     } catch (error) {}
   }

--- a/src/community/data/status-user.ts
+++ b/src/community/data/status-user.ts
@@ -1,0 +1,12 @@
+import { User } from 'src/user/entity/user.entity';
+import { UserStatus } from './user-status';
+
+export class StatusUser extends User {
+  status: UserStatus;
+}
+
+export const mergeUserAndStatus = (user: User, status: UserStatus) => {
+  const result: StatusUser = user as StatusUser;
+  result.status = status;
+  return result;
+};

--- a/src/friend/friend.controller.ts
+++ b/src/friend/friend.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseIntPipe,
   Post,
   Req,
+  SerializeOptions,
   UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';


### PR DESCRIPTION
## 작업 내용
friend에 class-trasformer가 적용되도록 수정했습니다.
## 공유 사항
```ts
import { User } from 'src/user/entity/user.entity';
import { UserStatus } from './user-status';

export class StatusUser extends User {
  status: UserStatus;
}

export const mergeUserAndStatus = (user: User, status: UserStatus) => {
  const result: StatusUser = user as StatusUser;
  result.status = status;
  return result;
};
```
위와 같이 status와 User를 합쳐서 반환하는 식으로 해결했습니다.

